### PR TITLE
Lowered the limit value to max accepted in firefly iii

### DIFF
--- a/custom_components/fireflyiii_integration/integrations/fireflyiii.py
+++ b/custom_components/fireflyiii_integration/integrations/fireflyiii.py
@@ -60,7 +60,7 @@ class Fireflyiii:
     def _set_max_limit(self, params: dict):
         """Sets max limits to avoid paging"""
         if "limit" not in params:
-            params["limit"] = 9999999999
+            params["limit"] = 131337
 
     @property
     async def version(self) -> str:


### PR DESCRIPTION
Since later version of FireFly III there is an upper limit if the "limit" parameter in the GET requests for accounts. This change reflect the new value and makes the GET requests for accounts during setup work.